### PR TITLE
Remove the GUID

### DIFF
--- a/src/internal/common/definition-identifier.ts
+++ b/src/internal/common/definition-identifier.ts
@@ -7,16 +7,13 @@ export abstract class DefinitionIdentifier implements IDefinitionIdentifier {
   public static readonly [_internal] = {
     label: "object",
     schema: Joi.object({
-      id: Joi.string().uuid().required(),
-      identifiers: Identifiers[_internal].schema,
+      id: Joi.string().required()
     }),
   };
 
   public readonly id: UUID;
-  public readonly identifiers: Identifiers;
 
   public constructor(pojo: DefinitionIdentifierPOJO) {
     this.id = pojo.id;
-    this.identifiers = new Identifiers(pojo.identifiers);
   }
 }

--- a/src/internal/common/reference-map.ts
+++ b/src/internal/common/reference-map.ts
@@ -1,25 +1,25 @@
-import { ErrorCode, UUID } from "../../public";
+import { ErrorCode } from "../../public";
 import { error } from "./errors";
 import { ShipEngineConstructor } from "./types";
 import { _internal } from "./utils";
 import { Joi, validate } from "./validation";
 
-interface ClassInstance { id: UUID; }
+interface ClassInstance { id: string; }
 
 interface Reference {
   type: ShipEngineConstructor;
   instance: ClassInstance;
 }
 
-const classInstanceSchema = Joi.object({ id: Joi.string().uuid() }).unknown(true);
+const classInstanceSchema = Joi.object({ id: Joi.string() }).unknown(true);
 const _private = Symbol("private fields");
 
 /**
- * Maps ShipEngine Integration Platform classes by their UUIDs
+ * Maps ShipEngine Integration Platform classes by their Id's
  */
 export class ReferenceMap {
   private readonly [_private] = {
-    map: new Map<UUID, Reference>(),
+    map: new Map<string, Reference>(),
     isFinishedLoading: false,
   };
 
@@ -36,8 +36,8 @@ export class ReferenceMap {
     if (existing) {
       // We already have a reference to this instance. Just make sure the types match.
       if (existing.type !== type) {
-        // There are two different objects with the same UUID
-        throw error(ErrorCode.Validation, `Duplicate UUID: ${instance.id}`);
+        // There are two different objects with the same Id
+        throw error(ErrorCode.Validation, `Duplicate Id's: ${instance.id}`);
       }
     }
     else {
@@ -74,7 +74,7 @@ export class ReferenceMap {
   }
 
   /**
-   * Returns the class instance that corresponds to the specified UUID, or throws an error if not found
+   * Returns the class instance that corresponds to the specified Id, or throws an error if not found
    */
   public lookup<T extends ClassInstance>(
     instance: ClassInstance, type: ShipEngineConstructor<T>): T;

--- a/src/public/common/definition-identifier.ts
+++ b/src/public/common/definition-identifier.ts
@@ -1,19 +1,13 @@
 import type { Identifiers, IdentifiersPOJO } from "./identifiers";
-import type { UUID } from "./types";
 
 /**
  * Identifies an object in an app definition
  */
 export interface DefinitionIdentifierPOJO {
   /**
-   * A UUID that uniquely identifies the object. This ID should never change.
+   * The unique identifier for this object. This ID should never change.
    */
-  id: UUID;
-
-  /**
-   * Your own identifiers for the object
-   */
-  identifiers?: IdentifiersPOJO;
+  id: string;
 }
 
 /**
@@ -21,12 +15,7 @@ export interface DefinitionIdentifierPOJO {
  */
 export interface DefinitionIdentifier {
   /**
-   * A UUID that uniquely identifies the object. This ID should never change.
+   * The unique identifier for this object. This ID should never change.
    */
-  readonly id: UUID;
-
-  /**
-   * Your own identifiers for the object
-   */
-  readonly identifiers: Identifiers;
+  readonly id: string;
 }


### PR DESCRIPTION
**Reasoning**

- Having people generate GUID's fundamentally feels wrong
- Having to map the carrier's definition of ids for packaging & services to an internal id felt bad and took more time than should have to be spent.  

